### PR TITLE
Converting to use generic package in preparation for chef 12.6. Issue #2

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -18,7 +18,7 @@
 # limitations under the License.
 #
 
-windows_package node['seven_zip']['package_name'] do
+package node['seven_zip']['package_name'] do
   source node['seven_zip']['url']
   checksum node['seven_zip']['checksum']
   options "INSTALLDIR=\"#{node['seven_zip']['home']}\"" if node['seven_zip']['home']


### PR DESCRIPTION
windows_package is being deprecated in Chef 12.6.
It's not currently an issue, but this will allow this cookbook to continue to be used 