### PR TITLE
Honoring overwite: false by using Skip All command line. Issue #3

### DIFF
--- a/providers/archive.rb
+++ b/providers/archive.rb
@@ -34,8 +34,9 @@ action :extract do
   converge_by("Extract #{@new_resource.source} => #{@new_resource.path} (overwrite=#{@new_resource.overwrite})") do
     FileUtils.mkdir_p(@new_resource.path) unless Dir.exist?(@new_resource.path)
     local_source = cached_file(@new_resource.source, @new_resource.checksum)
+    overwrite_file = @new_resource.overwrite ? ' -y' : ' -aos'
     cmd = "\"#{seven_zip_exe}\" x"
-    cmd << ' -y' if @new_resource.overwrite
+    cmd << overwrite_file
     cmd << " -o\"#{win_friendly_path(@new_resource.path)}\""
     cmd << " \"#{local_source}\""
     Chef::Log.debug(cmd)


### PR DESCRIPTION
overwrite: false currently causes the console window to ask for user input. This is not helpful during a Chef run.
This will tell 7Zip to use the Skip All command line option to only extract the new / missing files.