### PR TITLE
Pin `windows` cookbook version to 2.1.1

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -8,4 +8,4 @@ description      'Installs/Configures the 7-zip file archiver'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version          '2.0.2'
 supports         'windows'
-depends          'windows', '>= 1.2.2, < 3.0'
+depends          'windows', '>= 1.2.2', '< 3.0'

--- a/metadata.rb
+++ b/metadata.rb
@@ -8,4 +8,4 @@ description      'Installs/Configures the 7-zip file archiver'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version          '2.0.2'
 supports         'windows'
-depends          'windows', '~> 2.1.1'
+depends          'windows', '>= 1.2.2, < 3.0'

--- a/metadata.rb
+++ b/metadata.rb
@@ -8,4 +8,4 @@ description      'Installs/Configures the 7-zip file archiver'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version          '2.0.2'
 supports         'windows'
-depends          'windows', '>= 1.2.2', '< 3.0'
+depends          'windows', '< 3.0'

--- a/metadata.rb
+++ b/metadata.rb
@@ -8,4 +8,4 @@ description      'Installs/Configures the 7-zip file archiver'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version          '2.0.2'
 supports         'windows'
-depends          'windows', '>= 1.2.2'
+depends          'windows', '~> 2.1.1'


### PR DESCRIPTION
In `windows` cookbook >=3.0 there is no `cached_file` helper anymore.
So fall back to using 2.1.1 version.

Fixes https://github.com/windowschefcookbooks/seven_zip/issues/7