### PR TITLE
Update windows cookbook to latest v3.0.4

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -9,4 +9,4 @@ description      'Installs/Configures the 7-zip file archiver'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version          '2.0.2'
 supports         'windows'
-depends          'windows', '< 3.0'
+depends          'windows', '>= 3.0.4'


### PR DESCRIPTION
As v3.0.4 restores `cached_file` we can safely upgrade to this version.

Fixes
https://github.com/windowschefcookbooks/seven_zip/issues/10
https://github.com/windowschefcookbooks/seven_zip/issues/9
https://github.com/windowschefcookbooks/seven_zip/issues/2