### PR TITLE
Add seven_zip_tool resource to simplify setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,32 @@ seven_zip_archive 'seven_zip_source' do
 end
 ```
 
+## seven_zip_tool
+Download and install 7-zip for the current Windows platform.
+
+#### Actions
+- `:install` - Installs 7-zip
+- `:add_to_path` - Add 7-zip to the PATH
+
+#### Attribute Parameters
+- `package` - The name of the package.
+- `path` - The install directory of 7-zip.
+- `source` - The source URL of the 7-zip package.
+- `checksum` - The 7-zip package checksum.
+
+#### Examples
+Install 7-zip in `C:\7z` and add it to the path.
+
+```ruby
+seven_zip_tool '7z 15.14 install' do
+  action    [:install, :add_to_path]
+  package   '7-Zip 15.14'
+  path      'C:\7z'
+  source    'http://www.7-zip.org/a/7z1514.msi'
+  checksum  'eaf58e29941d8ca95045946949d75d9b5455fac167df979a7f8e4a6bf2d39680'
+end
+```
+
 # Recipes
 ## default
 

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -18,24 +18,7 @@
 # limitations under the License.
 #
 
-windows_package node['seven_zip']['package_name'] do
-  source node['seven_zip']['url']
-  checksum node['seven_zip']['checksum']
-  options "INSTALLDIR=\"#{node['seven_zip']['home']}\"" if node['seven_zip']['home']
-  action :install
+# Install 7z and optionally add it to path
+seven_zip_tool 'install seven_zip' do
+  action [:install, :add_to_path] if node['seven_zip']['syspath']
 end
-
-# update path
-windows_path 'seven_zip' do
-  path lazy {
-    if node['seven_zip']['home']
-      node['seven_zip']['home']
-    else
-      ::Win32::Registry::HKEY_LOCAL_MACHINE.open(
-        'SOFTWARE\Microsoft\Windows\CurrentVersion\App Paths\7zFM.exe',
-        ::Win32::Registry::KEY_READ
-      ).read_s('Path')
-    end
-  }
-  action :add
-end if node['seven_zip']['syspath']

--- a/resources/tool.rb
+++ b/resources/tool.rb
@@ -1,0 +1,47 @@
+#
+# Author:: Annih (<b.courtois@criteo.com>)
+# Cookbook:: seven_zip
+# Resource:: tool
+#
+# Copyright:: 2018, Baptiste Courtois
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+property :package, ::String, default: lazy { node['seven_zip']['package_name'] }
+property :source, ::String, default: lazy { node['seven_zip']['url'] }
+property :checksum, [::NilClass, ::String], default: lazy { node['seven_zip']['checksum'] }
+property :path, [::NilClass, ::String], default: lazy { node['seven_zip']['home'] }
+
+action :install do
+  windows_package new_resource.package do
+    action :install
+    source new_resource.source
+    checksum new_resource.checksum unless new_resource.checksum.nil?
+    options "INSTALLDIR=\"#{new_resource.path}\"" unless new_resource.path.nil?
+  end
+end
+
+action :add_to_path do
+  windows_path 'seven_zip' do
+    action :add
+    path new_resource.path || registry_path
+  end
+end
+
+action_class do
+  REG_PATH = 'SOFTWARE\Microsoft\Windows\CurrentVersion\App Paths\7zFM.exe'.freeze
+
+  def registry_path
+    ::Win32::Registry::HKEY_LOCAL_MACHINE.open(REG_PATH, ::Win32::Registry::KEY_READ).read_s('Path')
+  end
+end

--- a/spec/default_spec.rb
+++ b/spec/default_spec.rb
@@ -1,7 +1,7 @@
 describe 'seven_zip::default' do
   context 'with defaults' do
     let(:chef_run) do
-      ChefSpec::ServerRunner.new.converge(described_recipe)
+      ChefSpec::ServerRunner.new(step_into: 'seven_zip_tool').converge(described_recipe)
     end
     it 'installs seven_zip package' do
       expect(chef_run).to install_windows_package '7-Zip 18.05 (x64 edition)'
@@ -12,7 +12,7 @@ describe 'seven_zip::default' do
   end
   context 'with syspath' do
     let(:chef_run) do
-      ChefSpec::ServerRunner.new do |node|
+      ChefSpec::ServerRunner.new(step_into: 'seven_zip_tool') do |node|
         node.override['seven_zip']['syspath'] = true
         node.override['seven_zip']['home'] = 'C:\\\\7-zip'
       end.converge(described_recipe)


### PR DESCRIPTION
Having a simple resource to setup 7-zip allows other resources (since including a recipe inside a resource is not a good pattern) to use it to ensure that their prerequisites are installed before-hand.

This resource leverage existing attributes as default values to keep backward compatibility.
The seven_zip::default recipe's code has been refactored to just use this resource.