### PR TITLE
Resolve deprecation for win_friendly_path

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -12,9 +12,13 @@ driver:
 
 provisioner:
   name: chef_zero
+  product_name: chef
+  product_version: 13.8.5
 
 platforms:
   - name: windows-2012R2
+    transport:
+      name: winrm
     driver:
       box: mwrock/Windows2012R2
 

--- a/providers/archive.rb
+++ b/providers/archive.rb
@@ -20,6 +20,7 @@
 
 require 'fileutils'
 require 'chef/mixin/shell_out'
+require 'chef/util/path_helper'
 
 include Chef::Mixin::ShellOut
 include Windows::Helper
@@ -35,7 +36,7 @@ action :extract do
     overwrite_file = @new_resource.overwrite ? ' -y' : ' -aos'
     cmd = "\"#{seven_zip_exe}\" x"
     cmd << overwrite_file
-    cmd << " -o\"#{win_friendly_path(@new_resource.path)}\""
+    cmd << " -o\"#{Chef::Util::PathHelper.cleanpath(@new_resource.path)}\""
     cmd << " \"#{local_source}\""
     Chef::Log.debug(cmd)
     shell_out!(cmd, timeout: extract_timeout)
@@ -49,7 +50,7 @@ def seven_zip_exe
            seven_zip_exe_from_registry
          end
   Chef::Log.debug("Using 7-zip home: #{path}")
-  win_friendly_path(::File.join(path, '7z.exe'))
+  Chef::Util::PathHelper.cleanpath(::File.join(path, '7z.exe'))
 end
 
 def seven_zip_exe_from_registry

--- a/providers/archive.rb
+++ b/providers/archive.rb
@@ -44,11 +44,7 @@ action :extract do
 end
 
 def seven_zip_exe
-  path = if node['seven_zip']['home']
-           node['seven_zip']['home']
-         else
-           seven_zip_exe_from_registry
-         end
+  path = node['seven_zip']['home'] || seven_zip_exe_from_registry
   Chef::Log.debug("Using 7-zip home: #{path}")
   Chef::Util::PathHelper.cleanpath(::File.join(path, '7z.exe'))
 end


### PR DESCRIPTION
Do as suggested in the deprecation message and switch two calls to `Chef::Util::PathHelper.cleanpath`.

```
WARN: The win_friendly_path helper has been deprecated and will be removed from the next major release of the windows cookbook. Please update any cookbooks using this helper to instead require `chef/util/path_helper` and then use `Chef::Util::PathHelper.cleanpath`.
```